### PR TITLE
Add support for Gradle 7 syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,49 +1,44 @@
-apply plugin: 'com.gradle.plugin-publish'
-apply plugin: 'groovy'
-apply plugin: 'maven'
-
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
-  }
-}
-
-repositories {
-  jcenter()
-  mavenCentral()
+plugins {
+    id 'java'
+    id 'groovy'
+    id 'java-gradle-plugin'
+    id 'maven-publish'
 }
 
 group = 'org.ros2.tools.gradle'
 version = '0.8.0'
 
-uploadArchives {
-  repositories {
-    mavenLocal()
-  }
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
-dependencies {
-  compile gradleApi()
-  compile localGroovy()
-  compile 'com.android.tools.build:gradle:2.3.0'
-  runtime 'com.android.tools.build:gradle:2.3.0'
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    google()
 }
 
-pluginBundle {
-  website = 'https://github.com/esteve/ament_gradle_plugin'
-  vcsUrl = 'https://github.com/esteve/ament_gradle_plugin'
-  description = 'A Gradle plugin for building Java and Android-based ROS2 projects'
-  tags = ['ament', 'rcljava', 'robotics', 'ros2']
-
-  plugins {
-    ament {
-      id = 'org.ros2.tools.gradle'
-      displayName = 'A Gradle plugin for building Java and Android-based ROS2 projects'
+gradlePlugin {
+    plugins {
+        ament {
+            id = 'org.ros2.tools.gradle'
+            implementationClass = 'org.ros2.tools.gradle.AmentPlugin'
+        }
     }
-  }
+}
+
+tasks.withType(Copy).configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
 }

--- a/src/main/groovy/org/ros2/tools/gradle/JavaAmentPluginExtension.groovy
+++ b/src/main/groovy/org/ros2/tools/gradle/JavaAmentPluginExtension.groovy
@@ -45,7 +45,7 @@ class JavaAmentPluginExtension extends BaseAmentPluginExtension {
 
   def updateJavaOutput() {
     project.jar {
-      destinationDir = project.file(
+      destinationDirectory = project.file(
         [this.installSpace, 'share',
           this.packageManifestName,
           'java'].join(File.separator)
@@ -54,7 +54,7 @@ class JavaAmentPluginExtension extends BaseAmentPluginExtension {
   }
 
   def updateJavaDependencies() {
-    def compileDeps = project.getConfigurations().getByName('compile').getDependencies()
+    def compileDeps = project.getConfigurations().getByName('implementation').getDependencies()
     def fileDeps = project.files(project.ament.dependencies.split(':').collect {
       project.fileTree(dir: [it, 'java'].join(File.separator), include: '*.jar')
     })


### PR DESCRIPTION
Replaces deprecated `compile` configuration with `implementation`, and deprecated `destinationDir` keyword with `destinationDirectory`.